### PR TITLE
Delete the AWS access key from `creds.json.template`

### DIFF
--- a/creds.json.template
+++ b/creds.json.template
@@ -1,6 +1,6 @@
 {
   "r53_accountname": {
-    "KeyId": "AKIA3R6K7LQ6NBFLYQ53",
-    "SecretKey": "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"
+    "KeyId": "",
+    "SecretKey": ""
   }
 }


### PR DESCRIPTION

The `creds.json.template` file accidentally contained valid AWS access
key. The key has been deleted from AWS, thus it's not necessary to clean
it from the repository.